### PR TITLE
Fix two reproducible regressions from recent PR changes

### DIFF
--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,25 +1,27 @@
 // test/index.spec.ts
 import { env, createExecutionContext, waitOnExecutionContext, SELF } from 'cloudflare:test';
 import { describe, it, expect } from 'vitest';
-import worker from '../src/index';
+import worker from '../backend/src/index';
 
 // For now, you'll need to do something like this to get a correctly-typed
 // `Request` to pass to `worker.fetch()`.
 const IncomingRequest = Request<unknown, IncomingRequestCfProperties>;
 
-describe('Hello World worker', () => {
-	it('responds with Hello World! (unit style)', async () => {
+describe('Financeiro worker', () => {
+	it('retorna 404 para rota inexistente (unit style)', async () => {
 		const request = new IncomingRequest('http://example.com');
 		// Create an empty context to pass to `worker.fetch()`.
 		const ctx = createExecutionContext();
 		const response = await worker.fetch(request, env, ctx);
 		// Wait for all `Promise`s passed to `ctx.waitUntil()` to settle before running test assertions
 		await waitOnExecutionContext(ctx);
-		expect(await response.text()).toMatchInlineSnapshot(`"Hello World!"`);
+		expect(response.status).toBe(404);
+		expect(await response.text()).toBe('Rota não encontrada');
 	});
 
-	it('responds with Hello World! (integration style)', async () => {
+	it('retorna 404 para rota inexistente (integration style)', async () => {
 		const response = await SELF.fetch('https://example.com');
-		expect(await response.text()).toMatchInlineSnapshot(`"Hello World!"`);
+		expect(response.status).toBe(404);
+		expect(await response.text()).toBe('Rota não encontrada');
 	});
 });

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,5 +1,5 @@
 name = "financeiro-fazendalageado"
-main = "src/index.ts"
+main = "backend/src/index.ts"
 compatibility_date = "2024-02-06"
 compatibility_flags = ["nodejs_compat"]
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Fixed a broken Vitest worker import in `test/index.spec.ts` by targeting the real worker entrypoint (`backend/src/index`).
- Updated stale test expectations from scaffolded "Hello World" to current app behavior (`404` + `Rota não encontrada` for unknown route).
- Fixed `wrangler.toml` `main` path from `src/index.ts` to `backend/src/index.ts`.

## Reproduction and validation
### Bug 1: tests failing
- Reproduced with `npm test` (failed to resolve `../src/index` from `test/index.spec.ts`).
- After fix, `npm test -- --run` passes (2 tests).

### Bug 2: wrangler.toml startup failure
- Reproduced with `npx wrangler dev --config wrangler.toml --port 8787` (entrypoint `src/index.ts` not found).
- After fix, same command starts successfully and serves on `http://localhost:8787`.

## Scope
- Minimal, targeted changes in 2 files only.
- No dependency changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a6e488ff-3f28-43b1-b5ca-a319945f182e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a6e488ff-3f28-43b1-b5ca-a319945f182e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

